### PR TITLE
Convert timezone to UTC+08:00 for schedule comparison

### DIFF
--- a/src/app/components/CourseScheduleParser.tsx
+++ b/src/app/components/CourseScheduleParser.tsx
@@ -58,9 +58,21 @@ const CourseScheduleParser: React.FC<{ onParse: (info: CourseInfo) => void }> = 
     parseSchedule();
   }, [scheduleData, onParse]);
 
+  const detectTimezoneOffset = (): number => {
+    return new Date().getTimezoneOffset();
+  };
+
+  const convertToUTC8 = (date: Date): Date => {
+    const offset = detectTimezoneOffset();
+    const utc8Offset = -480; // UTC+08:00 offset in minutes
+    const diff = utc8Offset - offset;
+    return new Date(date.getTime() + diff * 60000);
+  };
+
   const getCourseInfo = (schedule: ScheduleData, date: Date): CourseInfo => {
-    const day = date.getDay() === 0 ? 7 : date.getDay();
-    const currentTime = date.toTimeString().slice(0, 5);
+    const convertedDate = convertToUTC8(date);
+    const day = convertedDate.getDay() === 0 ? 7 : convertedDate.getDay();
+    const currentTime = convertedDate.toTimeString().slice(0, 5);
     
     const todayCourses = schedule.schedule[day];
     

--- a/src/app/components/CourseScheduleParser.tsx
+++ b/src/app/components/CourseScheduleParser.tsx
@@ -58,10 +58,12 @@ const CourseScheduleParser: React.FC<{ onParse: (info: CourseInfo) => void }> = 
     parseSchedule();
   }, [scheduleData, onParse]);
 
+  // Function to detect user's timezone offset
   const detectTimezoneOffset = (): number => {
     return new Date().getTimezoneOffset();
   };
 
+  // Function to convert date to UTC+08:00
   const convertToUTC8 = (date: Date): Date => {
     const offset = detectTimezoneOffset();
     const utc8Offset = -480; // UTC+08:00 offset in minutes
@@ -69,6 +71,7 @@ const CourseScheduleParser: React.FC<{ onParse: (info: CourseInfo) => void }> = 
     return new Date(date.getTime() + diff * 60000);
   };
 
+  // Function to get course information based on the current date and time
   const getCourseInfo = (schedule: ScheduleData, date: Date): CourseInfo => {
     const convertedDate = convertToUTC8(date);
     const day = convertedDate.getDay() === 0 ? 7 : convertedDate.getDay();

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
         <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
             <p className='text-md'><a href="/">[家]</a> <a href="/full-course-schedule">[完整的课程表]</a></p>
             <p className='text-md desc'>Made with LOVE by <b><a href='https://caozhi.li'>Caozhi Li</a></b>, from CKG, CHN.</p>
-            <p className='text-sm desc'>※ 若你的时区并非中国标准时间 [(UTC+08:00) 北京，重庆，香港，乌鲁木齐] 或其他东八区时间，课程显示可能有误。</p>
+            <p className='text-sm desc'>※ 课程时间已转换为中国标准时间 [(UTC+08:00) 北京，重庆，香港，乌鲁木齐] 或其他东八区时间，以确保显示准确。</p>
         </footer>
     );
 };

--- a/src/app/components/FullCourseScheduleTable.tsx
+++ b/src/app/components/FullCourseScheduleTable.tsx
@@ -37,6 +37,27 @@ const FullCourseScheduleTable: React.FC = () => {
         fetchSchedule();
     }, []);
 
+    const detectTimezoneOffset = (): number => {
+        return new Date().getTimezoneOffset();
+    };
+
+    const convertToUTC8 = (timeSlot: string): string => {
+        const [startTime, endTime] = timeSlot.split('-');
+        const offset = detectTimezoneOffset();
+        const utc8Offset = -480; // UTC+08:00 offset in minutes
+        const diff = utc8Offset - offset;
+
+        const convertTime = (time: string): string => {
+            const [hours, minutes] = time.split(':').map(Number);
+            const date = new Date();
+            date.setHours(hours, minutes);
+            date.setMinutes(date.getMinutes() + diff);
+            return date.toTimeString().slice(0, 5);
+        };
+
+        return `${convertTime(startTime)}-${convertTime(endTime)}`;
+    };
+
     const getDayName = (day: number): string => {
         const days = ['周一', '周二', '周三', '周四', '周五', '周六', '周日'];
         return days[day - 1];
@@ -52,6 +73,7 @@ const FullCourseScheduleTable: React.FC = () => {
             const dayCourses = scheduleData.schedule[day.toString()] || [];
 
             scheduleData.timeSlots.forEach((timeSlot, timeSlotIndex) => {
+                const convertedTimeSlot = convertToUTC8(timeSlot);
                 const courseSlot = dayCourses.find(([slotIndex]) => slotIndex === timeSlotIndex);
 
                 if (courseSlot) {
@@ -61,14 +83,14 @@ const FullCourseScheduleTable: React.FC = () => {
                         let courseName = course.name;
 
                         // Add suffix based on time and day
-                        if (timeSlot === "07:30-07:50") {
+                        if (convertedTimeSlot === "07:30-07:50") {
                             courseName += "早读";
-                        } else if (timeSlot === "13:10-13:40") {
+                        } else if (convertedTimeSlot === "13:10-13:40") {
                             courseName += "午自习";
-                        } else if (day != 7 && timeSlot === "21:20-22:00") {
+                        } else if (day != 7 && convertedTimeSlot === "21:20-22:00") {
                             courseName += "考练";
-                        } else if ((day === 1 && timeSlot === "16:25-17:05") ||
-                            (day === 7 && (timeSlot === "19:40-20:20" || timeSlot === "20:30-21:10"))) {
+                        } else if ((day === 1 && convertedTimeSlot === "16:25-17:05") ||
+                            (day === 7 && (convertedTimeSlot === "19:40-20:20" || convertedTimeSlot === "20:30-21:10"))) {
                             courseName += "考练";
                         }
 

--- a/src/app/components/FullCourseScheduleTable.tsx
+++ b/src/app/components/FullCourseScheduleTable.tsx
@@ -37,10 +37,12 @@ const FullCourseScheduleTable: React.FC = () => {
         fetchSchedule();
     }, []);
 
+    // Function to detect user's timezone offset
     const detectTimezoneOffset = (): number => {
         return new Date().getTimezoneOffset();
     };
 
+    // Function to convert time slot to UTC+08:00
     const convertToUTC8 = (timeSlot: string): string => {
         const [startTime, endTime] = timeSlot.split('-');
         const offset = detectTimezoneOffset();
@@ -63,6 +65,7 @@ const FullCourseScheduleTable: React.FC = () => {
         return days[day - 1];
     };
 
+    // Function to create the schedule grid with converted time slots
     const createScheduleGrid = (): (CourseCell | null)[][] => {
         if (!scheduleData) return [];
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,15 +30,30 @@ const App: React.FC = () => {
     }
   };
 
+  const detectTimezoneOffset = (): number => {
+    return new Date().getTimezoneOffset();
+  };
+
+  const convertToUTC8 = (date: Date): Date => {
+    const offset = detectTimezoneOffset();
+    const utc8Offset = -480; // UTC+08:00 offset in minutes
+    const diff = utc8Offset - offset;
+    return new Date(date.getTime() + diff * 60000);
+  };
+
   const handleParsedInfo = (info: { current: Course | null, next: Course | null }) => {
     console.log('Current course:', info.current);
     console.log('Next course:', info.next);
 
     if (info.current) {
+      const convertedCurrentTime = convertToUTC8(new Date());
+      info.current.time = `${convertedCurrentTime.getHours()}:${convertedCurrentTime.getMinutes()}`;
       appendName(info.current);
     }
 
     if (info.next) {
+      const convertedNextTime = convertToUTC8(new Date());
+      info.next.time = `${convertedNextTime.getHours()}:${convertedNextTime.getMinutes()}`;
       appendName(info.next);
     }
 


### PR DESCRIPTION
Add timezone detection and conversion to UTC+08:00 for schedule comparison and display.

* **CourseScheduleParser.tsx**
  - Add functions to detect user's timezone and convert times to UTC+08:00.
  - Modify `getCourseInfo` to use converted time for comparison.

* **FullCourseScheduleTable.tsx**
  - Add functions to detect user's timezone and convert time slots to UTC+08:00.
  - Modify `createScheduleGrid` to use converted time slots.

* **page.tsx**
  - Add functions to detect user's timezone and convert current and next course times to UTC+08:00.
  - Modify `handleParsedInfo` to use converted times.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LiCaoZ/class.licaoz.com/pull/1?shareId=81f59f5d-70da-4f76-a296-9a424e9f22d3).