### PR TITLE
Fix timezone conversion in CourseScheduleParser

### DIFF
--- a/src/app/components/CourseScheduleParser.tsx
+++ b/src/app/components/CourseScheduleParser.tsx
@@ -58,9 +58,22 @@ const CourseScheduleParser: React.FC<{ onParse: (info: CourseInfo) => void }> = 
     parseSchedule();
   }, [scheduleData, onParse]);
 
+  const convertToUTC8 = (date: Date): Date => {
+    const offset = date.getTimezoneOffset();
+    const utc8Offset = -480; // UTC+8 is 480 minutes ahead of UTC
+    const diff = utc8Offset - offset;
+    return new Date(date.getTime() + diff * 60000);
+  };
+
+  const isUTC8 = (date: Date): boolean => {
+    const offset = date.getTimezoneOffset();
+    return offset === -480;
+  };
+
   const getCourseInfo = (schedule: ScheduleData, date: Date): CourseInfo => {
-    const day = date.getDay() === 0 ? 7 : date.getDay();
-    const currentTime = date.toTimeString().slice(0, 5);
+    const utc8Date = isUTC8(date) ? date : convertToUTC8(date);
+    const day = utc8Date.getDay() === 0 ? 7 : utc8Date.getDay();
+    const currentTime = utc8Date.toTimeString().slice(0, 5);
     
     const todayCourses = schedule.schedule[day];
     


### PR DESCRIPTION
Add timezone check and conversion to UTC+8 in `CourseScheduleParser.tsx`.

* **Add `convertToUTC8` function**
  - Convert the browser's local time to UTC+8 if necessary.

* **Add `isUTC8` function**
  - Check if the current timezone is UTC+8.

* **Modify `getCourseInfo` function**
  - Use `convertToUTC8` before extracting the current time.
  - Update `currentTime` logic to use the converted time if the browser's local time is not in UTC+8.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LiCaoZ/class.licaoz.com/pull/2?shareId=5fb9fcd5-7ee6-4b6f-8829-77edb95d8289).