### PR TITLE
Add error message for failed course schedule fetch

### DIFF
--- a/src/app/components/FullCourseScheduleTable.tsx
+++ b/src/app/components/FullCourseScheduleTable.tsx
@@ -22,6 +22,7 @@ interface CourseCell {
 
 const FullCourseScheduleTable: React.FC = () => {
     const [scheduleData, setScheduleData] = useState<ScheduleData | null>(null);
+    const [fetchError, setFetchError] = useState<boolean>(false);
 
     useEffect(() => {
         const fetchSchedule = async () => {
@@ -31,6 +32,7 @@ const FullCourseScheduleTable: React.FC = () => {
                 setScheduleData(data);
             } catch (error) {
                 console.error('Failed to fetch schedule:', error);
+                setFetchError(true);
             }
         };
 
@@ -90,6 +92,10 @@ const FullCourseScheduleTable: React.FC = () => {
 
         return grid;
     };
+
+    if (fetchError) {
+        return <div className="text-gray-800 dark:text-gray-200">课程表数据文件损坏或丢失。</div>;
+    }
 
     if (!scheduleData) {
         return <div className="text-gray-200 dark:text-gray-300">Loading...</div>;


### PR DESCRIPTION
Add error message display for failed course schedule fetch in `FullCourseScheduleTable.tsx`.

* Add a state variable `fetchError` to track fetch errors.
* Update the `fetchSchedule` function to set `fetchError` to true if the fetch fails.
* Add conditional rendering to display the error message "课程表数据文件损坏或丢失。" if `fetchError` is true.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LiCaoZ/class.licaoz.com/pull/3?shareId=60208040-7595-4546-9bcc-96b50e20f4ed).